### PR TITLE
Use instant crate on wasm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ version = "stable"
 futures-timer = "3.0.2"
 futures = "0.3.5"
 
+[target.'cfg(target_family = "wasm")'.dependencies]
+instant = "0.1.12"
+
 [dev-dependencies]
 proptest = "0.10.0"
 smol = "0.1.18"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,12 +2,12 @@
 
 use futures::{stream::Stream, task::Context};
 use futures_timer::Delay;
-use std::{
-    future::Future,
-    pin::Pin,
-    task::Poll,
-    time::{Duration, Instant},
-};
+use std::{future::Future, pin::Pin, task::Poll, time::Duration};
+
+#[cfg(target_family = "wasm")]
+use instant::Instant;
+#[cfg(not(target_family = "wasm"))]
+use std::time::Instant;
 
 /// Yields the current time in regular intervals.
 ///


### PR DESCRIPTION
`std::time::Instant::now` doesn't work on wasm, this crate seems to be the popular replacement