### PR TITLE
fix: reduce the number of calls to Instant::now

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,13 +80,13 @@ impl Stream for Ticker {
 
             Poll::Ready(_) => {
                 let now = Instant::now();
-                let next = self.next_tick();
+                let next = self.next_tick_from(now);
                 self.next = next;
                 self.schedule.reset(
                     next.checked_duration_since(now)
                         .unwrap_or_else(|| Duration::from_nanos(0)),
                 );
-                Poll::Ready(Some(Instant::now()))
+                Poll::Ready(Some(now))
             }
         }
     }


### PR DESCRIPTION
Instead of calling `Instant::now` 3 times

1. `let now = Instant::now();`
2. Within `self.next_tick();`
3. `Poll::Ready(Some(Instant::now()))`

call `Instant::now` once.

While `Instant::now` might not always trigger a operating system call, reducing the number at least reduces code complexity.