### PR TITLE
Update futures for cargo deny

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ version = "stable"
 
 [dependencies]
 futures-timer = "3.0.2"
-futures = "0.3.5"
+futures = "0.3.28"
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 instant = "0.1.12"

--- a/deny.toml
+++ b/deny.toml
@@ -12,6 +12,7 @@ allow = [
     "BSD-3-Clause",
     "BSD-2-Clause",
     "MIT",
+    "Unicode-DFS-2016", # for unicode-ident
 ]
 deny = []
 copyleft = "warn"
@@ -40,5 +41,4 @@ skip = [
 skip-tree = [
     # criterion & proptest pull in old versions of rand & are dev-dependencies:
     { name = "proptest", version = "*", depth = 3 },
-    { name = "wasi", version = "0.9"}
 ]


### PR DESCRIPTION
Deny is failing because we don't allow the Unicode license, so let's.